### PR TITLE
Add object support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A new programming language with semantics borrowed from the Swahili language to help teach programming concepts to native Swahili-speaking students.
 
-![Version 0.6.6](https://img.shields.io/badge/version-0.6.6-blue)
+![Version 0.7.1](https://img.shields.io/badge/version-0.7.1-blue)
 [![Run on Repl.it](https://repl.it/badge/github/malcolmkiano/swahili)](https://repl.it/@moredigital/swahili-1)
 
 ## Get Started

--- a/bin/interpreter/nodes.js
+++ b/bin/interpreter/nodes.js
@@ -52,6 +52,16 @@ class StringNode {
   }
 }
 
+/** node representing an object */
+class ObjectNode {
+  constructor(propertyNodes, posStart, posEnd) {
+    this.propertyNodes = propertyNodes;
+
+    this.posStart = posStart;
+    this.posEnd = posEnd;
+  }
+}
+
 /** node representing a list */
 class ListNode {
   constructor(elementNodes, posStart, posEnd) {
@@ -59,6 +69,38 @@ class ListNode {
 
     this.posStart = posStart;
     this.posEnd = posEnd;
+  }
+}
+
+/** node representing a property access result */
+class PropAccessNode {
+  /**
+   * instantiates a property access node
+   * @param {Token} varNameTok token containing the property's name
+   * @param {PropAccessNode} parent node containing any parent properties being accessed
+   */
+  constructor(varNameTok, parent = null) {
+    this.varNameTok = varNameTok;
+    this.parent = parent;
+
+    this.posStart = this.varNameTok.posStart;
+    this.posEnd = this.varNameTok.posEnd;
+  }
+}
+
+/** node representing a property assignment */
+class PropAssignNode {
+  /**
+   * instantiates a property assignment node
+   * @param {Token[]} nodeChain list of tokens containing the property's name
+   * @param {Node} valueNode node containing the value to be assigned to the property
+   */
+  constructor(nodeChain, valueNode) {
+    this.nodeChain = nodeChain;
+    this.valueNode = valueNode;
+
+    this.posStart = this.nodeChain[0].posStart;
+    this.posEnd = this.valueNode.posEnd;
   }
 }
 
@@ -342,7 +384,10 @@ class BreakNode {
 module.exports = {
   NumberNode,
   StringNode,
+  ObjectNode,
   ListNode,
+  PropAccessNode,
+  PropAssignNode,
   VarAccessNode,
   VarAssignNode,
   VarDefNode,

--- a/bin/interpreter/run.js
+++ b/bin/interpreter/run.js
@@ -5,8 +5,6 @@ const Interpreter = require('./');
 const SymbolTable = require('./symbolTable');
 
 const SWBuiltInFunction = require('./types/built-in-function');
-const SWBoolean = require('./types/boolean');
-const SWNull = require('./types/null');
 const { libFunctions, libConstants } = require('./lib');
 
 /** holds all variables and their values in the global scope */

--- a/bin/interpreter/types/base-function.js
+++ b/bin/interpreter/types/base-function.js
@@ -52,14 +52,6 @@ class SWBaseFunction extends SWObject {
     return res.success(SWNull.NULL);
   }
 
-  /**
-   * returns true
-   * @returns {Boolean}
-   */
-  isTrue() {
-    return true;
-  }
-
   [util.inspect.custom](depth, options) {
     return this.toString();
   }

--- a/bin/interpreter/types/base-function.js
+++ b/bin/interpreter/types/base-function.js
@@ -1,14 +1,14 @@
 const util = require('util');
 const colors = require('colors');
 
-const SWValue = require('./value');
+const SWObject = require('./object');
 const SWNull = require('./null');
 const RTResult = require('../runtimeResult');
 const Context = require('../context');
 const SymbolTable = require('../symbolTable');
 
 /** Base function type */
-class SWBaseFunction extends SWValue {
+class SWBaseFunction extends SWObject {
   /**
    * instantiates a function
    * @param {String} name name of the function
@@ -18,7 +18,6 @@ class SWBaseFunction extends SWValue {
   constructor(name) {
     super();
     this.name = name || '<isiyotambuliwa>';
-    this.symbolTable = new SymbolTable();
   }
 
   /**
@@ -46,7 +45,7 @@ class SWBaseFunction extends SWValue {
       if (argValue) {
         argValue.setContext(executionContext);
         executionContext.symbolTable.set(argName, argValue);
-        this.symbolTable.set(`__${argName}`, argValue);
+        this.symbolTable.set(argName, argValue);
       }
     }
 

--- a/bin/interpreter/types/list.js
+++ b/bin/interpreter/types/list.js
@@ -1,8 +1,6 @@
 const util = require('util');
-const colors = require('colors');
 const SWValue = require('./value');
 const SWBoolean = require('./boolean');
-const SWNull = require('./null');
 const SWNumber = require('./number');
 
 const { RTError } = require('../error');
@@ -131,7 +129,7 @@ class SWList extends SWValue {
   }
 
   /**
-   * string representation of the number class
+   * string representation of the list class
    * @param {Boolean} showBrackets whether to show brackets and color or not
    * @returns {String}
    */

--- a/bin/interpreter/types/object.js
+++ b/bin/interpreter/types/object.js
@@ -1,0 +1,61 @@
+const util = require('util');
+
+const SWValue = require('./value');
+const SymbolTable = require('../symbolTable');
+
+/** Object data type */
+class SWObject extends SWValue {
+  /**
+   * instantiates an object
+   * @param {Node[]} symbols nodes containing the properties of the object
+   */
+  constructor(symbols = []) {
+    super();
+    this.symbolTable = new SymbolTable();
+    this.populateSymbols(symbols);
+  }
+
+  /**
+   * adds symbols to an object's symbol table
+   * @param {Node[]} symbols nodes containing the properties of the object
+   */
+  populateSymbols(symbols) {
+    for (let { name, value } of symbols) {
+      this.symbolTable.set(name, value);
+    }
+  }
+
+  /**
+   * creates a new instance of the object
+   * @returns {SWObject}
+   */
+  copy() {
+    let symbolMap = Object.entries(
+      this.symbolTable.symbols
+    ).map(([name, value]) => ({ name, value }));
+    let copy = new SWObject(symbolMap);
+    copy.setPosition(this.posStart, this.posEnd);
+    copy.setContext(this.context);
+    return copy;
+  }
+
+  [util.inspect.custom](depth, options) {
+    return this.toString();
+  }
+
+  /**
+   * string representation of the object class
+   * @param {Boolean} expose whether to show a breakdown of the object or not
+   * @returns {String}
+   */
+  toString(expose = true) {
+    let elements = this.symbolTable.symbols;
+    let output = [];
+    for (let [name, value] of Object.entries(elements)) {
+      output.push(`${name}: ${value.toString()}`);
+    }
+    return expose ? `{ ${output.join(', ')} }` : `[SWObject]`;
+  }
+}
+
+module.exports = SWObject;

--- a/bin/interpreter/types/object.js
+++ b/bin/interpreter/types/object.js
@@ -1,6 +1,7 @@
 const util = require('util');
 
 const SWValue = require('./value');
+const SWBoolean = require('./boolean');
 const SymbolTable = require('../symbolTable');
 
 /** Object data type */
@@ -29,6 +30,22 @@ class SWObject extends SWValue {
   }
 
   /**
+   * returns true
+   * @returns {Boolean}
+   */
+  isTrue() {
+    return true;
+  }
+
+  /**
+   * returns false if instance value is falsy (this is an object, so it will always return false)
+   * @returns {SWBoolean}
+   */
+  notted() {
+    return [new SWBoolean(!this.isTrue()).setContext(this.context), null];
+  }
+
+  /**
    * creates a new instance of the object
    * @returns {SWObject}
    */
@@ -53,11 +70,13 @@ class SWObject extends SWValue {
    */
   toString(expose = true) {
     let elements = this.symbolTable.symbols;
+    let entries = Object.entries(elements);
+    let s = entries.length ? ' ' : ''; // spaces to be shown if object has values
     let output = [];
-    for (let [name, value] of Object.entries(elements)) {
+    for (let [name, value] of entries) {
       output.push(`${name}: ${value.toString()}`);
     }
-    return expose ? `{ ${output.join(', ')} }` : `[SWObject]`;
+    return expose ? `{${s}${output.join(', ')}${s}}` : `[SWObject]`;
   }
 }
 

--- a/bin/interpreter/types/object.js
+++ b/bin/interpreter/types/object.js
@@ -21,6 +21,9 @@ class SWObject extends SWValue {
    */
   populateSymbols(symbols) {
     for (let { name, value } of symbols) {
+      // add a reference to this object in all child functions
+      if (value instanceof SWObject) value.symbolTable.setConstant('hii', this);
+
       this.symbolTable.set(name, value);
     }
   }

--- a/bin/interpreter/types/value.js
+++ b/bin/interpreter/types/value.js
@@ -25,7 +25,7 @@ class SWValue {
   /**
    * Sets the context in which the value node occurs
    * @param {Context} context the calling context
-   * @returns {value}
+   * @returns {SWValue}
    */
   setContext(context = null) {
     this.context = context;

--- a/bin/lexer/index.js
+++ b/bin/lexer/index.js
@@ -334,6 +334,12 @@ class Lexer {
       } else if (LEX.rightCurly.test(this.currentChar)) {
         tokens.push(new Token(TT.RCURL, null, this.pos));
         this.advance();
+      } else if (LEX.dot.test(this.currentChar)) {
+        tokens.push(new Token(TT.DOT, null, this.pos));
+        this.advance();
+      } else if (LEX.col.test(this.currentChar)) {
+        tokens.push(new Token(TT.COL, null, this.pos));
+        this.advance();
       } else if (LEX.comma.test(this.currentChar)) {
         tokens.push(new Token(TT.COMMA, null, this.pos));
         this.advance();

--- a/bin/lexer/lexemes.js
+++ b/bin/lexer/lexemes.js
@@ -17,6 +17,8 @@ module.exports = {
   rightSquare: /\]/,
   leftCurly: /\{/,
   rightCurly: /\}/,
+  dot: /\./,
+  col: /:/,
   comma: /,/,
   ampersand: /&/,
   pipe: /\|/,

--- a/bin/lexer/tokenTypes.js
+++ b/bin/lexer/tokenTypes.js
@@ -72,6 +72,12 @@ module.exports = {
   /** Greater than or equal comparison */
   GTE: 'GTE',
 
+  /** Dot */
+  DOT: 'DOT',
+
+  /** Colon */
+  COL: 'COL',
+
   /** Comma */
   COMMA: 'COMMA',
 

--- a/bin/parser/index.js
+++ b/bin/parser/index.js
@@ -1169,6 +1169,12 @@ class Parser {
     this.advance();
     let argNameToks = [];
 
+    // skip past any new lines
+    while (this.currentTok.type === TT.NEWLINE) {
+      res.registerAdvancement();
+      this.advance();
+    }
+
     if (this.currentTok.type === TT.IDENTIFIER) {
       argNameToks.push(this.currentTok);
       res.registerAdvancement();
@@ -1177,6 +1183,12 @@ class Parser {
       while (this.currentTok.type === TT.COMMA) {
         res.registerAdvancement();
         this.advance();
+
+        // skip past any more new lines
+        while (this.currentTok.type === TT.NEWLINE) {
+          res.registerAdvancement();
+          this.advance();
+        }
 
         if (this.currentTok.type !== TT.IDENTIFIER)
           return res.failure(

--- a/bin/parser/index.js
+++ b/bin/parser/index.js
@@ -5,7 +5,10 @@ const { InvalidSyntaxError } = require('../interpreter/error');
 const {
   NumberNode,
   StringNode,
+  ObjectNode,
   ListNode,
+  PropAccessNode,
+  PropAssignNode,
   VarAccessNode,
   VarAssignNode,
   VarDefNode,
@@ -430,9 +433,13 @@ class Parser {
         );
       }
     } else if (tok.type === TT.IDENTIFIER) {
-      res.registerAdvancement();
-      this.advance();
-      return res.success(new VarAccessNode(tok));
+      let access = res.register(this.access());
+      if (res.error) return res;
+      return res.success(access);
+    } else if (tok.type === TT.LCURL) {
+      let objExpr = res.register(this.objExpr());
+      if (res.error) return res;
+      return res.success(objExpr);
     } else if (tok.type === TT.LSQUARE) {
       let listExpr = res.register(this.listExpr());
       if (res.error) return res;
@@ -470,6 +477,192 @@ class Parser {
     );
   };
 
+  /** parse tokens to make an access token */
+  access = () => {
+    let res = new ParseResult();
+    let nodeChain = [];
+
+    if (this.currentTok.type !== TT.IDENTIFIER)
+      return res.failure(
+        new InvalidSyntaxError(
+          this.currentTok.posStart,
+          this.currentTok.posEnd,
+          `Expected '${lc(TT.IDENTIFIER)}'`
+        )
+      );
+
+    let varNameTok = this.currentTok;
+    let currentNode = new PropAccessNode(varNameTok);
+    nodeChain.push(varNameTok);
+
+    res.registerAdvancement();
+    this.advance();
+
+    while (this.currentTok.type === TT.DOT) {
+      res.registerAdvancement();
+      this.advance();
+
+      if (this.currentTok.type === TT.IDENTIFIER) {
+        varNameTok = this.currentTok;
+        currentNode = new PropAccessNode(varNameTok, currentNode);
+        nodeChain.push(varNameTok);
+      } else {
+        return res.failure(
+          new InvalidSyntaxError(
+            this.currentTok.posStart,
+            this.currentTok.posEnd,
+            `Expected '${lc(TT.IDENTIFIER)}'`
+          )
+        );
+      }
+
+      res.registerAdvancement();
+      this.advance();
+    }
+
+    if (!currentNode.parent) {
+      currentNode = new VarAccessNode(varNameTok);
+    } else {
+      if (this.currentTok.type === TT.EQ) {
+        res.registerAdvancement();
+        this.advance();
+
+        let valueNode = res.register(this.expr());
+        if (res.error) return res;
+
+        currentNode = new PropAssignNode(nodeChain, valueNode);
+      }
+    }
+
+    return res.success(currentNode);
+  };
+
+  /** parse tokens to make an object node */
+  objExpr = () => {
+    let res = new ParseResult();
+    let propertyNodes = [];
+    let posStart = this.currentTok.posStart.copy();
+
+    if (this.currentTok.type !== TT.LCURL)
+      return res.failure(
+        new InvalidSyntaxError(
+          this.currentTok.posStart,
+          this.currentTok.posEnd,
+          `Expected '${lc(TT.LCURL)}'`
+        )
+      );
+
+    res.registerAdvancement();
+    this.advance();
+
+    if (this.currentTok.type === TT.RCURL) {
+      res.registerAdvancement();
+      this.advance();
+    } else {
+      // skip past any new lines after [
+      while (this.currentTok.type === TT.NEWLINE) {
+        res.registerAdvancement();
+        this.advance();
+      }
+
+      if (this.currentTok.type !== TT.IDENTIFIER)
+        return res.failure(
+          new InvalidSyntaxError(
+            this.currentTok.posStart,
+            this.currentTok.posEnd,
+            `Expected '${lc(TT.IDENTIFIER)}'`
+          )
+        );
+
+      let propertyName = this.currentTok;
+      res.registerAdvancement();
+      this.advance();
+
+      if (this.currentTok.type !== TT.COL)
+        return res.failure(
+          new InvalidSyntaxError(
+            this.currentTok.posStart,
+            this.currentTok.posEnd,
+            `Expected '${lc(LEX.col.source)}'`
+          )
+        );
+
+      res.registerAdvancement();
+      this.advance();
+
+      let valueNode = res.register(this.expr());
+      if (res.error) return res;
+
+      propertyNodes.push(new PropAssignNode([propertyName], valueNode));
+
+      while (this.currentTok.type === TT.COMMA) {
+        res.registerAdvancement();
+        this.advance();
+
+        // skip past any new lines after between properties
+        while (this.currentTok.type === TT.NEWLINE) {
+          res.registerAdvancement();
+          this.advance();
+        }
+
+        if (this.currentTok.type !== TT.IDENTIFIER)
+          return res.failure(
+            new InvalidSyntaxError(
+              this.currentTok.posStart,
+              this.currentTok.posEnd,
+              `Expected '${lc(TT.IDENTIFIER)}'`
+            )
+          );
+
+        propertyName = this.currentTok;
+        res.registerAdvancement();
+        this.advance();
+
+        if (this.currentTok.type !== TT.COL)
+          return res.failure(
+            new InvalidSyntaxError(
+              this.currentTok.posStart,
+              this.currentTok.posEnd,
+              `Expected '${lc(LEX.col.source)}'`
+            )
+          );
+
+        res.registerAdvancement();
+        this.advance();
+
+        valueNode = res.register(this.expr());
+        if (res.error) return res;
+
+        propertyNodes.push(new PropAssignNode([propertyName], valueNode));
+      }
+
+      // skip past any new lines
+      while (this.currentTok.type === TT.NEWLINE) {
+        res.registerAdvancement();
+        this.advance();
+      }
+
+      if (this.currentTok.type !== TT.RCURL) {
+        return res.failure(
+          new InvalidSyntaxError(
+            this.currentTok.posStart,
+            this.currentTok.posEnd,
+            `Expected '${lc(LEX.comma.source)}' or '${lc(
+              LEX.rightCurly.source
+            )}'`
+          )
+        );
+      }
+
+      res.registerAdvancement();
+      this.advance();
+    }
+
+    return res.success(
+      new ObjectNode(propertyNodes, posStart, this.currentTok.posEnd.copy())
+    );
+  };
+
   /** parse tokens to make a list node */
   listExpr = () => {
     let res = new ParseResult();
@@ -481,7 +674,7 @@ class Parser {
         new InvalidSyntaxError(
           this.currentTok.posStart,
           this.currentTok.posEnd,
-          `Expected '['`
+          `Expected '${lc(TT.LSQUARE)}'`
         )
       );
 

--- a/bin/parser/index.js
+++ b/bin/parser/index.js
@@ -487,7 +487,7 @@ class Parser {
         new InvalidSyntaxError(
           this.currentTok.posStart,
           this.currentTok.posEnd,
-          `Expected '${lc(TT.IDENTIFIER)}'`
+          `Expected ${lc(TT.IDENTIFIER)}`
         )
       );
 
@@ -511,7 +511,7 @@ class Parser {
           new InvalidSyntaxError(
             this.currentTok.posStart,
             this.currentTok.posEnd,
-            `Expected '${lc(TT.IDENTIFIER)}'`
+            `Expected ${lc(TT.IDENTIFIER)}`
           )
         );
       }
@@ -570,7 +570,7 @@ class Parser {
           new InvalidSyntaxError(
             this.currentTok.posStart,
             this.currentTok.posEnd,
-            `Expected '${lc(TT.IDENTIFIER)}'`
+            `Expected ${lc(TT.IDENTIFIER)}`
           )
         );
 
@@ -610,7 +610,7 @@ class Parser {
             new InvalidSyntaxError(
               this.currentTok.posStart,
               this.currentTok.posEnd,
-              `Expected '${lc(TT.IDENTIFIER)}'`
+              `Expected ${lc(TT.IDENTIFIER)}`
             )
           );
 

--- a/docs/ref/grammar.md
+++ b/docs/ref/grammar.md
@@ -2,44 +2,48 @@
 
 This will be updated as the language develops
 
-| Node              | Constituents                                             |
-| :---------------- | :------------------------------------------------------- |
-| **statements**    | NEWLINE* `statement` (NEWLINE+ `statement`)*             |
-| **statement**     | KEYWORD:RUDISHA `expr`?                                  |
-|                   | KEYWORD:ENDELEA                                          |
-|                   | KEYWORD:ONDOKA                                           |
-|                   | IDENTIFIER EQ `expr`                                     |
-|                   | `expr`                                                   |
-| **expr**          | KEYWORD:WACHA IDENTIFIER EQ `expr`                       |
-|                   | `comp-expr` ((AND\|OR) `comp-expr`)\*                    |
-| **comp-expr**     | NOT `comp-expr`                                          |
-|                   | `arith-expr` ((EE\|LT\|GT\|LTE\|GTE) `arith-expr`)\*     |
-| **arith-expr**    | `term` ((PLUS\|MINUS) `term`)\*                          |
-| **term**          | `factor` (MUL\|DIV\|MOD) `factor`)\*                     |
-| **factor**        | (PLUS\|MINUS) `factor`                                   |
-|                   | `power`                                                  |
-| **power**         | `call` (POW `factor`)\*                                  |
-| **call**          | `atom` (LPAREN (`expr` (COMMA `expr`)\*)? RPAREN)?       |
-| **atom**          | INT\|FLOAT\|STRING\|IDENTIFIER                           |
-|                   | LPAREN `expr` RPAREN                                     |
-|                   | `list-expr`                                              |
-|                   | `if-expr`                                                |
-|                   | `while-expr`                                             |
-|                   | `func-def`                                               |
-|                   | `for-expr`                                               |
-|                   | `for-each-expr`                                          |
-| **list-expr**     | LSQUARE (`expr` (COMMA `expr`)\*)? RSQUARE               |
-| **if-expr**       | KEYWORD:KAMA `expr` LCURL                                |
-|                   | (`statements` RCURL `if-expr-b`\|`if-expr-c`?)           |
-| **if-expr-b**     | KEYWORD:AU `expr` LCURL                                  |
-|                   | (`statements` RCURL `if-expr-b`\|`if-expr-c`?)           |
-| **if-expr-c**     | KEYWORD:SIVYO LCURL `statements` RCURL                   |
-| **while-expr**    | KEYWORD:AMBAPO `expr` LCURL `statements` RCURL           |
-| **func-def**      | KEYWORD:SHUGHULI IDENTIFIER?                             |
-|                   | LPAREN (IDENTIFIER (COMMA IDENTIFIER)\*)? RPAREN         |
-|                   | LCURL `statements` RCURL                                 |
-| **for-expr**      | KEYWORD:KWA IDENTIFIER (`for-to-expr`\|`for-each-expr`)  |
-| **for-to-expr**   | EQ `expr` KEYWORD:MPAKA `expr` (KEYWORD:HATUA `expr`)?   |
-|                   | LCURL `statements` RCURL                                 |
-| **for-each-expr** | KEYWORD:KATIKA (STRING\|IDENTIFIER\|`list-expr`\|`call`) |
-|                   | LCURL `statements` RCURL                                 |
+| Node              | Constituents                                                         |
+| :---------------- | :------------------------------------------------------------------- |
+| **statements**    | NEWLINE* `statement` (NEWLINE+ `statement`)*                         |
+| **statement**     | KEYWORD:RUDISHA `expr`?                                              |
+|                   | KEYWORD:ENDELEA                                                      |
+|                   | KEYWORD:ONDOKA                                                       |
+|                   | IDENTIFIER EQ `expr`                                                 |
+|                   | `expr`                                                               |
+| **expr**          | KEYWORD:WACHA IDENTIFIER EQ `expr`                                   |
+|                   | `comp-expr` ((AND\|OR) `comp-expr`)\*                                |
+| **comp-expr**     | NOT `comp-expr`                                                      |
+|                   | `arith-expr` ((EE\|LT\|GT\|LTE\|GTE) `arith-expr`)\*                 |
+| **arith-expr**    | `term` ((PLUS\|MINUS) `term`)\*                                      |
+| **term**          | `factor` (MUL\|DIV\|MOD) `factor`)\*                                 |
+| **factor**        | (PLUS\|MINUS) `factor`                                               |
+|                   | `power`                                                              |
+| **power**         | `call` (POW `factor`)\*                                              |
+| **call**          | `atom` (LPAREN (`expr` (COMMA `expr`)\*)? RPAREN)?                   |
+| **atom**          | INT\|FLOAT\|STRING                                                   |
+|                   | LPAREN `expr` RPAREN                                                 |
+|                   | `access`                                                             |
+|                   | `obj-expr`                                                           |
+|                   | `list-expr`                                                          |
+|                   | `if-expr`                                                            |
+|                   | `while-expr`                                                         |
+|                   | `func-def`                                                           |
+|                   | `for-expr`                                                           |
+|                   | `for-each-expr`                                                      |
+| **access**        | IDENTIFIER(DOT IDENTIFIER)\*                                         |
+| **obj-expr**      | LCURL (IDENTIFIER COL `expr` (COMMA IDENTIFIER COL `expr`)\*)? RCURL |
+| **list-expr**     | LSQUARE (`expr` (COMMA `expr`)\*)? RSQUARE                           |
+| **if-expr**       | KEYWORD:KAMA `expr` LCURL                                            |
+|                   | (`statements` RCURL `if-expr-b`\|`if-expr-c`?)                       |
+| **if-expr-b**     | KEYWORD:AU `expr` LCURL                                              |
+|                   | (`statements` RCURL `if-expr-b`\|`if-expr-c`?)                       |
+| **if-expr-c**     | KEYWORD:SIVYO LCURL `statements` RCURL                               |
+| **while-expr**    | KEYWORD:AMBAPO `expr` LCURL `statements` RCURL                       |
+| **func-def**      | KEYWORD:SHUGHULI IDENTIFIER?                                         |
+|                   | LPAREN (IDENTIFIER (COMMA IDENTIFIER)\*)? RPAREN                     |
+|                   | LCURL `statements` RCURL                                             |
+| **for-expr**      | KEYWORD:KWA IDENTIFIER (`for-to-expr`\|`for-each-expr`)              |
+| **for-to-expr**   | EQ `expr` KEYWORD:MPAKA `expr` (KEYWORD:HATUA `expr`)?               |
+|                   | LCURL `statements` RCURL                                             |
+| **for-each-expr** | KEYWORD:KATIKA (STRING\|IDENTIFIER\|`list-expr`\|`call`)             |
+|                   | LCURL `statements` RCURL                                             |

--- a/examples/aina.swh
+++ b/examples/aina.swh
@@ -1,0 +1,23 @@
+shughuli Mtu(jina, mji, fedha) {
+  rudisha {
+    jina: jina,
+    mji: mji,
+    salimu: shughuli salimu() {
+      andika("Jambo! Jina langu ni " + jina + " kutoka " + mji + ".")
+    },
+    anaPesaNgapi: shughuli anaPesaNgapi() {
+      andika(jina + ": 'Siwezi kuambia, lakini ni karibu na " + Jina(fedha * 20) + "'")
+    }
+  }
+}
+
+wacha wendo = Mtu("Patrick", "Nairobi, Kenya", 5000)
+wacha kiano = Mtu("Malcolm", "Boston, USA", 3000)
+
+wendo.salimu()
+kiano.salimu()
+
+andika(wendo.jina) // => "Patrick"
+andika(wendo.fedha) // => "" (hamna jibu kwa kuwa hii mali imefichwa)
+
+wendo.anaPesaNgapi() // mali iliyofichwa inatumika kwenye shughuli za kamusi

--- a/examples/aina.swh
+++ b/examples/aina.swh
@@ -1,23 +1,21 @@
-shughuli Mtu(jina, mji, fedha) {
+shughuli Mtu(jina, umri, jinsia, jlu) {
   rudisha {
     jina: jina,
-    mji: mji,
+    umri: umri,
+    jinsia: jinsia,
+    jinaLaUtani: jlu,
     salimu: shughuli salimu() {
-      andika("Jambo! Jina langu ni " + jina + " kutoka " + mji + ".")
-    },
-    anaPesaNgapi: shughuli anaPesaNgapi() {
-      andika(jina + ": 'Siwezi kuambia, lakini ni karibu na " + Jina(fedha * 20) + "'")
+      wacha salamu = "Jambo! Jina langu ni " + hii.jina + "."
+      kama (!niTupu(hii.jinaLaUtani)) {
+        salamu = salamu + " Marafiki wangu huniita " + hii.jinaLaUtani + "."
+      }
+      andika(salamu)
     }
   }
 }
 
-wacha wendo = Mtu("Patrick", "Nairobi, Kenya", 5000)
-wacha kiano = Mtu("Malcolm", "Boston, USA", 3000)
+wacha mimi = Mtu("Malcolm", 24, "m")
+mimi.salimu()
 
-wendo.salimu()
-kiano.salimu()
-
-andika(wendo.jina) // => "Patrick"
-andika(wendo.fedha) // => "" (hamna jibu kwa kuwa hii mali imefichwa)
-
-wendo.anaPesaNgapi() // mali iliyofichwa inatumika kwenye shughuli za kamusi
+wacha wewe = Mtu("Patrick", 21, "m", "Wendo")
+wewe.salimu()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swahili-lang",
-  "version": "0.6.6",
+  "version": "0.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swahili-lang",
-  "version": "0.6.6",
+  "version": "0.7.1",
   "description": "A new programming language with semantics borrowed from the Swahili language to help teach programming concepts to Swahili speaking students.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Objects can now be defined just as any other variables.
```
wacha mtu = {
  jina: "John",
  umri: 28
}
```

Objects provide access to the `hii` (this) keyword, but **only within object methods**
So, this is valid.
```
wacha mtu = {jina: "Nancy", salimu: shughuli () { andika( "Jambo! Jina langu ni " + hii.jina + ".") } }
```

And this is invalid
```
wacha mtu = {jina: "Nancy", jinaKamili: "Binti " + hii.jina }
```