### PR TITLE
CLI improvements, remove file import ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A new programming language with semantics borrowed from the Swahili language to help teach programming concepts to native Swahili-speaking students.
 
-![Version 0.8.2](https://img.shields.io/badge/version-0.8.2-blue)
+![Version 0.8.3](https://img.shields.io/badge/version-0.8.3-blue)
 [![Run on Repl.it](https://repl.it/badge/github/malcolmkiano/swahili)](https://repl.it/@moredigital/swahili-1)
 
 ## Get Started

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
+require('module-alias/register');
 
-const info = require('../package.json');
 const args = process.argv.slice(2);
 const fs = require('fs');
-
 const colors = require('colors');
 const readline = require('readline');
 
-const print = require('./utils/print');
-const run = require('./interpreter/run');
+const info = require('@root/package.json');
+const print = require('@utils/print');
+const run = require('@int/run');
 
 /** set up terminal interface */
 const rl = readline.createInterface({
@@ -56,6 +56,21 @@ rl.on('SIGINT', () => {
   process.exit(0);
 });
 
+// help info
+const printHelp = () => {
+  print('Usage: swahili <option> <filename>', true);
+  print('where <option> is one of:');
+  print('-h, --help');
+  print('  Print this help', true);
+  print('-l, --load');
+  print('  Load a script at <filename> and run Swahili REPL', true);
+
+  print(
+    'swahili <filename>\tScript at <filename> will be executed and the program will exit'
+  );
+  print('swahili\t\t\tRun Swahili REPL');
+};
+
 let fileName;
 let load = false;
 
@@ -67,20 +82,14 @@ if (args.length) {
     print(colors.brightMagenta(`Swahili v${info.version}`));
     process.exit(0);
   } else if (['-h', '--help'].includes(args[0])) {
-    print('Usage: swahili <option> <filename>', true);
-    print('where <option> is one of:');
-    print('-h, --help');
-    print('  Print this help', true);
-    print('-l, --load');
-    print('  Load a script at <filename> and run Swahili REPL', true);
-
-    print(
-      'swahili <filename>\tScript at <filename> will be executed and the program will exit'
-    );
-    print('swahili\t\t\tRun Swahili REPL');
+    printHelp();
     process.exit(0);
   } else if (['-l', '--load'].includes(args[0])) {
     load = true;
+  } else if (args[0].startsWith('-')) {
+    print(colors.red(`${args[0]} is not a valid option`), true);
+    printHelp();
+    process.exit(1);
   }
 
   try {

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const info = require('../package.json');
 const args = process.argv.slice(2);
 const fs = require('fs');
 
@@ -55,11 +56,35 @@ rl.on('SIGINT', () => {
   process.exit(0);
 });
 
+let fileName;
+let load = false;
+
 if (args.length) {
-  let fileName = args[0];
+  fileName = args[0];
   let script = null;
 
+  if (['-v', '--version'].includes(args[0])) {
+    print(colors.brightMagenta(`Swahili v${info.version}`));
+    process.exit(0);
+  } else if (['-h', '--help'].includes(args[0])) {
+    print('Usage: swahili <option> <filename>', true);
+    print('where <option> is one of:');
+    print('-h, --help');
+    print('  Print this help', true);
+    print('-l, --load');
+    print('  Load a script at <filename> and run Swahili REPL', true);
+
+    print(
+      'swahili <filename>\tScript at <filename> will be executed and the program will exit'
+    );
+    print('swahili\t\t\tRun Swahili REPL');
+    process.exit(0);
+  } else if (['-l', '--load'].includes(args[0])) {
+    load = true;
+  }
+
   try {
+    if (load) fileName = args[1];
     if (fs.lstatSync(fileName).isDirectory()) {
       fileName = fileName.replace(/\/|\\/g, '/');
       fileName = fileName.split('/').filter(Boolean); // remove all falsy values
@@ -79,11 +104,16 @@ if (args.length) {
   }
 
   // process the file
-  const [result, error] = run(fileName, script, true);
+  const [result, error] = run(fileName, script, !load);
   handleOutput(result, error);
-  process.exit(0);
-} else {
-  // begin the repl
-  console.clear();
-  getInput();
+  if (!load) process.exit(0);
 }
+
+// begin the repl
+console.clear();
+if (load)
+  print(
+    `Script ${colors.green('"' + fileName + '"')} was successfully loaded.`,
+    true
+  );
+getInput();

--- a/bin/interpreter/error.js
+++ b/bin/interpreter/error.js
@@ -1,4 +1,4 @@
-const stringWithArrows = require('../utils/stringWithArrows');
+const stringWithArrows = require('@utils/stringWithArrows');
 
 class Error {
   /**

--- a/bin/interpreter/index.js
+++ b/bin/interpreter/index.js
@@ -1,17 +1,17 @@
-const TT = require('../lexer/tokenTypes');
+const TT = require('@lex/tokenTypes');
 
-const SWValue = require('./types/value');
-const SWNull = require('./types/null');
-const SWNumber = require('./types/number');
-const SWString = require('./types/string');
-const SWList = require('./types/list');
-const SWFunction = require('./types/function');
-const SWObject = require('./types/object');
+const SWValue = require('@types/value');
+const SWNull = require('@types/null');
+const SWNumber = require('@types/number');
+const SWString = require('@types/string');
+const SWList = require('@types/list');
+const SWFunction = require('@types/function');
+const SWObject = require('@types/object');
 
-const Context = require('./context');
-const SymbolTable = require('./symbolTable');
-const RTResult = require('./runtimeResult');
-const { RTError } = require('./error');
+const Context = require('@int/context');
+const SymbolTable = require('@int/symbolTable');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /** Analyzes abstract syntax trees from the parser and executes programs */
 class Interpreter {

--- a/bin/interpreter/lib/constants.js
+++ b/bin/interpreter/lib/constants.js
@@ -1,6 +1,6 @@
-const SWBoolean = require('../types/boolean');
-const SWString = require('../types/string');
-const SWNull = require('../types/null');
+const SWBoolean = require('@types/boolean');
+const SWString = require('@types/string');
+const SWNull = require('@types/null');
 
 // instantiate global constants
 module.exports = {

--- a/bin/interpreter/lib/index.js
+++ b/bin/interpreter/lib/index.js
@@ -1,47 +1,47 @@
 // =====================================================
 // Constants
-const constants = require('./constants');
+const constants = require('@lib/constants');
 
 // =====================================================
 // I/O methods
-const andika = require('./io/andika');
-const soma = require('./io/soma');
-const somaNambari = require('./io/somaNambari');
-const futa = require('./io/futa');
+const andika = require('@lib/io/andika');
+const soma = require('@lib/io/soma');
+const somaNambari = require('@lib/io/somaNambari');
+const futa = require('@lib/io/futa');
 
 // =====================================================
 // Type methods
 // > Checking
-const niNambari = require('./type/check/niNambari');
-const niJina = require('./type/check/niJina');
-const niOrodha = require('./type/check/niOrodha');
-const niShughuli = require('./type/check/niShughuli');
-const niTupu = require('./type/check/niTupu');
-const niTarehe = require('./type/check/niTarehe');
-const niKamusi = require('./type/check/niKamusi');
-const aina = require('./type/check/aina');
+const niNambari = require('@lib/type/check/niNambari');
+const niJina = require('@lib/type/check/niJina');
+const niOrodha = require('@lib/type/check/niOrodha');
+const niShughuli = require('@lib/type/check/niShughuli');
+const niTupu = require('@lib/type/check/niTupu');
+const niTarehe = require('@lib/type/check/niTarehe');
+const niKamusi = require('@lib/type/check/niKamusi');
+const aina = require('@lib/type/check/aina');
 
 // > Casting
-const Nambari = require('./type/cast/Nambari');
-const Jina = require('./type/cast/Jina');
-const Tarehe = require('./type/cast/Tarehe');
+const Nambari = require('@lib/type/cast/Nambari');
+const Jina = require('@lib/type/cast/Jina');
+const Tarehe = require('@lib/type/cast/Tarehe');
 
 // > Modification & reading
 // >>> Iterables (Lists & Strings)
-const idadi = require('./type/mod/iterable/idadi');
-const badili = require('./type/mod/list/badili');
+const idadi = require('@lib/type/mod/iterable/idadi');
+const badili = require('@lib/type/mod/list/badili');
 
 // >>> Lists
-const unga = require('./type/mod/list/unga');
+const unga = require('@lib/type/mod/list/unga');
 
 // >>> Strings
-const tenga = require('./type/mod/string/tenga');
-const herufiNdogo = require('./type/mod/string/herufiNdogo');
-const herufiKubwa = require('./type/mod/string/herufiKubwa');
+const tenga = require('@lib/type/mod/string/tenga');
+const herufiNdogo = require('@lib/type/mod/string/herufiNdogo');
+const herufiKubwa = require('@lib/type/mod/string/herufiKubwa');
 
 // >>> Numbers
-const ndogo = require('./type/mod/number/ndogo');
-const kubwa = require('./type/mod/number/kubwa');
+const ndogo = require('@lib/type/mod/number/ndogo');
+const kubwa = require('@lib/type/mod/number/kubwa');
 
 // =====================================================
 // Exports

--- a/bin/interpreter/lib/io/andika.js
+++ b/bin/interpreter/lib/io/andika.js
@@ -1,7 +1,7 @@
-const print = require('../../../utils/print');
-const SWNull = require('../../types/null');
-const RTResult = require('../../runtimeResult');
-const { RTError } = require('../../error');
+const print = require('@utils/print');
+const SWNull = require('@types/null');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Print a value to the screen

--- a/bin/interpreter/lib/io/futa.js
+++ b/bin/interpreter/lib/io/futa.js
@@ -1,5 +1,5 @@
-const SWNull = require('../../types/null');
-const RTResult = require('../../runtimeResult');
+const SWNull = require('@types/null');
+const RTResult = require('@int/runtimeResult');
 
 /**
  * Clears the terminal

--- a/bin/interpreter/lib/io/soma.js
+++ b/bin/interpreter/lib/io/soma.js
@@ -1,6 +1,6 @@
 const prompt = require('prompt-sync')();
-const SWString = require('../../types/string');
-const RTResult = require('../../runtimeResult');
+const SWString = require('@types/string');
+const RTResult = require('@int/runtimeResult');
 
 /**
  * Gets input from STDIN

--- a/bin/interpreter/lib/io/somaNambari.js
+++ b/bin/interpreter/lib/io/somaNambari.js
@@ -1,6 +1,6 @@
 const prompt = require('prompt-sync')();
-const SWNumber = require('../../types/number');
-const RTResult = require('../../runtimeResult');
+const SWNumber = require('@types/number');
+const RTResult = require('@int/runtimeResult');
 
 /**
  * Gets numeric input from STDIN

--- a/bin/interpreter/lib/type/cast/Jina.js
+++ b/bin/interpreter/lib/type/cast/Jina.js
@@ -1,7 +1,7 @@
-const SWString = require('../../../types/string');
-const SWBaseFunction = require('../../../types/base-function');
-const RTResult = require('../../../runtimeResult');
-const { RTError } = require('../../../error');
+const SWString = require('@types/string');
+const SWBaseFunction = require('@types/base-function');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Casts a value to a SWString

--- a/bin/interpreter/lib/type/cast/Nambari.js
+++ b/bin/interpreter/lib/type/cast/Nambari.js
@@ -1,8 +1,8 @@
-const SWString = require('../../../types/string');
-const SWNumber = require('../../../types/number');
-const SWBoolean = require('../../../types/boolean');
-const RTResult = require('../../../runtimeResult');
-const { RTError } = require('../../../error');
+const SWString = require('@types/string');
+const SWNumber = require('@types/number');
+const SWBoolean = require('@types/boolean');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Casts a value to a SWNumber

--- a/bin/interpreter/lib/type/cast/Tarehe.js
+++ b/bin/interpreter/lib/type/cast/Tarehe.js
@@ -1,7 +1,7 @@
-const SWString = require('../../../types/string');
-const SWDateTime = require('../../../types/datetime');
-const RTResult = require('../../../runtimeResult');
-const { RTError } = require('../../../error');
+const SWString = require('@types/string');
+const SWDateTime = require('@types/datetime');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Creates a new SWDateTime value, or formats one as a SWString

--- a/bin/interpreter/lib/type/check/aina.js
+++ b/bin/interpreter/lib/type/check/aina.js
@@ -1,7 +1,6 @@
-const SWString = require('../../../types/string');
-
-const RTResult = require('../../../runtimeResult');
-const { RTError } = require('../../../error');
+const SWString = require('@types/string');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Returns the type of a value

--- a/bin/interpreter/lib/type/check/niJina.js
+++ b/bin/interpreter/lib/type/check/niJina.js
@@ -1,7 +1,7 @@
-const SWBoolean = require('../../../types/boolean');
-const SWString = require('../../../types/string');
-const RTResult = require('../../../runtimeResult');
-const { RTError } = require('../../../error');
+const SWBoolean = require('@types/boolean');
+const SWString = require('@types/string');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Checks if a value is a string

--- a/bin/interpreter/lib/type/check/niKamusi.js
+++ b/bin/interpreter/lib/type/check/niKamusi.js
@@ -1,8 +1,8 @@
-const SWBoolean = require('../../../types/boolean');
-const SWObject = require('../../../types/object');
-const SWBaseFunction = require('../../../types/base-function');
-const RTResult = require('../../../runtimeResult');
-const { RTError } = require('../../../error');
+const SWBoolean = require('@types/boolean');
+const SWObject = require('@types/object');
+const SWBaseFunction = require('@types/base-function');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Checks if a value is an object

--- a/bin/interpreter/lib/type/check/niNambari.js
+++ b/bin/interpreter/lib/type/check/niNambari.js
@@ -1,7 +1,7 @@
-const SWBoolean = require('../../../types/boolean');
-const SWNumber = require('../../../types/number');
-const RTResult = require('../../../runtimeResult');
-const { RTError } = require('../../../error');
+const SWBoolean = require('@types/boolean');
+const SWNumber = require('@types/number');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Checks if a value is a number

--- a/bin/interpreter/lib/type/check/niOrodha.js
+++ b/bin/interpreter/lib/type/check/niOrodha.js
@@ -1,7 +1,7 @@
-const SWBoolean = require('../../../types/boolean');
-const SWList = require('../../../types/list');
-const RTResult = require('../../../runtimeResult');
-const { RTError } = require('../../../error');
+const SWBoolean = require('@types/boolean');
+const SWList = require('@types/list');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Checks if a value is a list

--- a/bin/interpreter/lib/type/check/niShughuli.js
+++ b/bin/interpreter/lib/type/check/niShughuli.js
@@ -1,7 +1,7 @@
-const SWBoolean = require('../../../types/boolean');
-const SWBaseFunction = require('../../../types/base-function');
-const RTResult = require('../../../runtimeResult');
-const { RTError } = require('../../../error');
+const SWBoolean = require('@types/boolean');
+const SWBaseFunction = require('@types/base-function');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Checks if a value is a function

--- a/bin/interpreter/lib/type/check/niTarehe.js
+++ b/bin/interpreter/lib/type/check/niTarehe.js
@@ -1,7 +1,7 @@
-const SWBoolean = require('../../../types/boolean');
-const SWDateTime = require('../../../types/datetime');
-const RTResult = require('../../../runtimeResult');
-const { RTError } = require('../../../error');
+const SWBoolean = require('@types/boolean');
+const SWDateTime = require('@types/datetime');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Checks if a value is a date

--- a/bin/interpreter/lib/type/check/niTupu.js
+++ b/bin/interpreter/lib/type/check/niTupu.js
@@ -1,6 +1,6 @@
-const SWBoolean = require('../../../types/boolean');
-const RTResult = require('../../../runtimeResult');
-const { RTError } = require('../../../error');
+const SWBoolean = require('@types/boolean');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Checks if a value is empty

--- a/bin/interpreter/lib/type/mod/iterable/idadi.js
+++ b/bin/interpreter/lib/type/mod/iterable/idadi.js
@@ -1,8 +1,8 @@
-const SWString = require('../../../../types/string');
-const SWList = require('../../../../types/list');
-const SWNumber = require('../../../../types/number');
-const RTResult = require('../../../../runtimeResult');
-const { RTError } = require('../../../../error');
+const SWString = require('@types/string');
+const SWList = require('@types/list');
+const SWNumber = require('@types/number');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Returns the length of a list/string

--- a/bin/interpreter/lib/type/mod/list/badili.js
+++ b/bin/interpreter/lib/type/mod/list/badili.js
@@ -1,7 +1,7 @@
-const SWList = require('../../../../types/list');
-const SWNumber = require('../../../../types/number');
-const RTResult = require('../../../../runtimeResult');
-const { RTError } = require('../../../../error');
+const SWList = require('@types/list');
+const SWNumber = require('@types/number');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Alters the element at the given index of a list

--- a/bin/interpreter/lib/type/mod/list/unga.js
+++ b/bin/interpreter/lib/type/mod/list/unga.js
@@ -1,7 +1,7 @@
-const SWList = require('../../../../types/list');
-const SWString = require('../../../../types/string');
-const RTResult = require('../../../../runtimeResult');
-const { RTError } = require('../../../../error');
+const SWList = require('@types/list');
+const SWString = require('@types/string');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Joins a list using a given join character

--- a/bin/interpreter/lib/type/mod/number/kubwa.js
+++ b/bin/interpreter/lib/type/mod/number/kubwa.js
@@ -1,8 +1,8 @@
-const SWNumber = require('../../../../types/number');
-const SWList = require('../../../../types/list');
+const SWNumber = require('@types/number');
+const SWList = require('@types/list');
 
-const RTResult = require('../../../../runtimeResult');
-const { RTError } = require('../../../../error');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Gets the highest number in a list

--- a/bin/interpreter/lib/type/mod/number/ndogo.js
+++ b/bin/interpreter/lib/type/mod/number/ndogo.js
@@ -1,8 +1,8 @@
-const SWNumber = require('../../../../types/number');
-const SWList = require('../../../../types/list');
+const SWNumber = require('@types/number');
+const SWList = require('@types/list');
 
-const RTResult = require('../../../../runtimeResult');
-const { RTError } = require('../../../../error');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 /**
  * Gets the lowest number in a list
  * @param {SWBuiltInFunction} inst the instance of the built in function

--- a/bin/interpreter/lib/type/mod/string/herufiKubwa.js
+++ b/bin/interpreter/lib/type/mod/string/herufiKubwa.js
@@ -1,6 +1,6 @@
-const SWString = require('../../../../types/string');
-const RTResult = require('../../../../runtimeResult');
-const { RTError } = require('../../../../error');
+const SWString = require('@types/string');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Converts a string to uppercase

--- a/bin/interpreter/lib/type/mod/string/herufiNdogo.js
+++ b/bin/interpreter/lib/type/mod/string/herufiNdogo.js
@@ -1,6 +1,6 @@
-const SWString = require('../../../../types/string');
-const RTResult = require('../../../../runtimeResult');
-const { RTError } = require('../../../../error');
+const SWString = require('@types/string');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Converts a string to lowercase

--- a/bin/interpreter/lib/type/mod/string/tenga.js
+++ b/bin/interpreter/lib/type/mod/string/tenga.js
@@ -1,7 +1,7 @@
-const SWList = require('../../../../types/list');
-const SWString = require('../../../../types/string');
-const RTResult = require('../../../../runtimeResult');
-const { RTError } = require('../../../../error');
+const SWList = require('@types/list');
+const SWString = require('@types/string');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**
  * Splits a string into a list using a given delimiter

--- a/bin/interpreter/run.js
+++ b/bin/interpreter/run.js
@@ -1,11 +1,11 @@
-const Lexer = require('../lexer');
-const Parser = require('../parser');
-const Context = require('./context');
-const Interpreter = require('./');
-const SymbolTable = require('./symbolTable');
+const Lexer = require('@lex');
+const Parser = require('@parse');
+const Context = require('@int/context');
+const Interpreter = require('@int');
+const SymbolTable = require('@int/symbolTable');
 
-const SWBuiltInFunction = require('./types/built-in-function');
-const { functions, constants } = require('./lib');
+const SWBuiltInFunction = require('@types/built-in-function');
+const { functions, constants } = require('@lib');
 
 /** holds all variables and their values in the global scope */
 const globalSymbolTable = new SymbolTable();

--- a/bin/interpreter/types/base-function.js
+++ b/bin/interpreter/types/base-function.js
@@ -1,12 +1,12 @@
 const util = require('util');
 const colors = require('colors');
 
-const SWList = require('./list');
-const SWObject = require('./object');
-const SWNull = require('./null');
-const RTResult = require('../runtimeResult');
-const Context = require('../context');
-const SymbolTable = require('../symbolTable');
+const SWList = require('@types/list');
+const SWObject = require('@types/object');
+const SWNull = require('@types/null');
+const RTResult = require('@int/runtimeResult');
+const Context = require('@int/context');
+const SymbolTable = require('@int/symbolTable');
 
 /** Base function type */
 class SWBaseFunction extends SWObject {

--- a/bin/interpreter/types/boolean.js
+++ b/bin/interpreter/types/boolean.js
@@ -1,6 +1,6 @@
 const util = require('util');
 const colors = require('colors');
-const SWValue = require('./value');
+const SWValue = require('@types/value');
 
 /**  Boolean data type */
 class SWBoolean extends SWValue {

--- a/bin/interpreter/types/built-in-function.js
+++ b/bin/interpreter/types/built-in-function.js
@@ -1,10 +1,10 @@
 const util = require('util');
 const colors = require('colors');
 
-const { functions } = require('../lib');
+const { functions } = require('@lib');
 
-const SWBaseFunction = require('./base-function');
-const RTResult = require('../runtimeResult');
+const SWBaseFunction = require('@types/base-function');
+const RTResult = require('@int/runtimeResult');
 
 /** Built in function data type */
 class SWBuiltInFunction extends SWBaseFunction {

--- a/bin/interpreter/types/datetime.js
+++ b/bin/interpreter/types/datetime.js
@@ -1,7 +1,7 @@
 const util = require('util');
 const colors = require('colors');
-const SWValue = require('./value');
-const SWString = require('./string');
+const SWValue = require('@types/value');
+const SWString = require('@types/string');
 
 /**  DateTime data type */
 class SWDateTime extends SWValue {

--- a/bin/interpreter/types/function.js
+++ b/bin/interpreter/types/function.js
@@ -1,7 +1,7 @@
-const SWBaseFunction = require('./base-function');
-const SWNull = require('./null');
-const RTResult = require('../runtimeResult');
-const SymbolTable = require('../symbolTable');
+const SWBaseFunction = require('@types/base-function');
+const SWNull = require('@types/null');
+const RTResult = require('@int/runtimeResult');
+const SymbolTable = require('@int/symbolTable');
 
 /** Function data type */
 class SWFunction extends SWBaseFunction {

--- a/bin/interpreter/types/list.js
+++ b/bin/interpreter/types/list.js
@@ -1,9 +1,9 @@
 const util = require('util');
-const SWValue = require('./value');
-const SWBoolean = require('./boolean');
-const SWNumber = require('./number');
+const SWValue = require('@types/value');
+const SWBoolean = require('@types/boolean');
+const SWNumber = require('@types/number');
 
-const { RTError } = require('../error');
+const { RTError } = require('@int/error');
 
 /**  List data type */
 class SWList extends SWValue {

--- a/bin/interpreter/types/null.js
+++ b/bin/interpreter/types/null.js
@@ -1,7 +1,7 @@
 const util = require('util');
 const colors = require('colors');
-const SWValue = require('./value');
-const SWBoolean = require('./boolean');
+const SWValue = require('@types/value');
+const SWBoolean = require('@types/boolean');
 
 /**  Null data type */
 class SWNull extends SWValue {

--- a/bin/interpreter/types/number.js
+++ b/bin/interpreter/types/number.js
@@ -1,8 +1,8 @@
 const util = require('util');
 const colors = require('colors');
-const SWValue = require('./value');
-const SWBoolean = require('./boolean');
-const { RTError } = require('../error');
+const SWValue = require('@types/value');
+const SWBoolean = require('@types/boolean');
+const { RTError } = require('@int/error');
 
 /**  Number data type */
 class SWNumber extends SWValue {

--- a/bin/interpreter/types/object.js
+++ b/bin/interpreter/types/object.js
@@ -1,8 +1,8 @@
 const util = require('util');
 
-const SWValue = require('./value');
-const SWBoolean = require('./boolean');
-const SymbolTable = require('../symbolTable');
+const SWValue = require('@types/value');
+const SWBoolean = require('@types/boolean');
+const SymbolTable = require('@int/symbolTable');
 
 /** Object data type */
 class SWObject extends SWValue {

--- a/bin/interpreter/types/string.js
+++ b/bin/interpreter/types/string.js
@@ -1,9 +1,9 @@
 const util = require('util');
 const colors = require('colors');
-const SWValue = require('./value');
-const SWNumber = require('./number');
-const SWBoolean = require('./boolean');
-const { RTError } = require('../error');
+const SWValue = require('@types/value');
+const SWNumber = require('@types/number');
+const SWBoolean = require('@types/boolean');
+const { RTError } = require('@int/error');
 
 /**  String data type */
 class SWString extends SWValue {

--- a/bin/interpreter/types/value.js
+++ b/bin/interpreter/types/value.js
@@ -1,7 +1,7 @@
 const util = require('util');
 const colors = require('colors');
-const RTResult = require('../runtimeResult');
-const { RTError } = require('../error');
+const RTResult = require('@int/runtimeResult');
+const { RTError } = require('@int/error');
 
 /**  Value base type */
 class SWValue {

--- a/bin/lexer/index.js
+++ b/bin/lexer/index.js
@@ -1,9 +1,9 @@
-const TT = require('./tokenTypes');
-const LEX = require('./lexemes');
+const TT = require('@lex/tokenTypes');
+const LEX = require('@lex/lexemes');
 
-const Token = require('./token');
-const Position = require('./position');
-const { IllegalCharError, ExpectedCharError } = require('../interpreter/error');
+const Token = require('@lex/token');
+const Position = require('@lex/position');
+const { IllegalCharError, ExpectedCharError } = require('@int/error');
 
 /**
  * Performs a lexical analysis to ensure correct syntax of the programming language

--- a/bin/lexer/position.js
+++ b/bin/lexer/position.js
@@ -1,4 +1,4 @@
-const LEX = require('./lexemes');
+const LEX = require('@lex/lexemes');
 
 /**
  * represents the exact line/colNumber/file position for the lexer, parser and interpreter

--- a/bin/parser/index.js
+++ b/bin/parser/index.js
@@ -1,7 +1,7 @@
-const TT = require('../lexer/tokenTypes');
-const LEX = require('../lexer/lexemes');
-const ParseResult = require('./parseResult');
-const { InvalidSyntaxError } = require('../interpreter/error');
+const TT = require('@lex/tokenTypes');
+const LEX = require('@lex/lexemes');
+const ParseResult = require('@parse/parseResult');
+const { InvalidSyntaxError } = require('@int/error');
 const {
   NumberNode,
   StringNode,
@@ -23,7 +23,7 @@ const {
   ReturnNode,
   ContinueNode,
   BreakNode,
-} = require('../interpreter/nodes');
+} = require('@int/nodes');
 
 // abstraction to make code shorter
 const lc = (str) => str.replace('\\', '').toLowerCase();

--- a/examples/aina.swh
+++ b/examples/aina.swh
@@ -1,29 +1,21 @@
-shughuli Mtu(jina, umri, jinsia, jlu) {
+// load this script with 'swahili -l ./examples/aina.swh'
+// anzisha programu hii kutumia 'swahili -l ./examples/aina.swh'
+
+shughuli Mtu(jina, umri, jlu) {
   rudisha {
     jina: jina,
     umri: umri,
-    jinsia: jinsia,
     jinaLaUtani: jlu,
-    salimu: shughuli salimu() {
+    salimu: shughuli () {
       wacha salamu = "Jambo! Jina langu ni " + hii.jina + "."
       kama (!niTupu(hii.jinaLaUtani)) {
         salamu = salamu + " Marafiki wangu huniita " + hii.jinaLaUtani + "."
       }
       andika(salamu)
     },
-    zeeka: shughuli zeeka() {
-      wacha umriMpya = hii.umri + 1
-      hii.umri = umriMpya
-      rudisha umriMpya
+    zeeka: shughuli () {
+      hii.umri = hii.umri + 1
+      rudisha hii.umri
     }
   }
 }
-
-wacha m = Mtu("Malcolm", 24, "m")
-m.salimu()
-
-wacha p = Mtu("Patrick", 21, "m", "Wendo")
-p.salimu()
-
-m.zeeka()
-andika(m.umri)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swahili-lang",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -655,6 +655,12 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "module-alias": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
+      "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swahili-lang",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "A new programming language with semantics borrowed from the Swahili language to help teach programming concepts to Swahili speaking students.",
   "repository": {
     "type": "git",
@@ -17,6 +17,15 @@
   "bin": {
     "swahili": "bin/index.js"
   },
+  "_moduleAliases": {
+    "@lib": "bin/interpreter/lib",
+    "@types": "bin/interpreter/types",
+    "@int": "bin/interpreter",
+    "@parse": "bin/parser",
+    "@lex": "bin/lexer",
+    "@utils": "bin/utils",
+    "@root": ""
+  },
   "keywords": [
     "swahili",
     "programming-language"
@@ -32,6 +41,7 @@
   },
   "devDependencies": {
     "eslint": "^7.7.0",
+    "module-alias": "^2.2.2",
     "pre-commit": "^1.2.2",
     "prettier": "^2.1.1"
   },


### PR DESCRIPTION
A lot of files changed because I went through updating the imports to use the aliases.
These are the available aliases and where they point
- **`@lib`**: `bin/interpreter/lib`,
- **`@types`**: `bin/interpreter/types`,
- **`@int`**: `bin/interpreter`,
- **`@parse`**: `bin/parser`,
- **`@lex`**: `bin/lexer`,
- **`@utils`**: `bin/utils`,
- **`@root`**: `/`
