### PR TITLE
fix: correct typo in tausworth error

### DIFF
--- a/bin/packages/yoyote/tausworth.js
+++ b/bin/packages/yoyote/tausworth.js
@@ -31,7 +31,7 @@ function tausworth(inst, executionContext) {
       new RTError(
         mwanzo.posStart,
         mwanzo.posEnd,
-        `Parameter 'miwsho' is required since 'mwanzo' is provided`,
+        `Parameter 'mwisho' is required since 'mwanzo' is provided`,
         executionContext
       )
     );


### PR DESCRIPTION
- Update `miwsho` to `mwisho` in Tausworth parameter error